### PR TITLE
Correct Typescript types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "immutable-sorted",
-  "version": "0.2.6",
+  "name": "@binaris/immutable-sorted",
+  "version": "0.2.7-binaris.3",
   "description": "Immutable Sorted Data Collections",
   "license": "MIT",
-  "homepage": "https://applitopia.github.io/immutable-sorted",
+  "homepage": "https://github.com/binaris/immutable-sorted",
   "repository": {
     "type": "git",
-    "url": "git://github.com/applitopia/immutable-sorted.git"
+    "url": "git://github.com/binaris/immutable-sorted.git"
   },
   "bugs": {
     "url": "https://github.com/applitopia/immutable-sorted/issues"
@@ -80,7 +80,6 @@
     "jasmine-check": "0.1.5",
     "jest": "21.2.1",
     "marked": "0.3.6",
-    "microtime": "2.1.6",
     "mkdirp": "0.5.1",
     "npm-run-all": "4.1.1",
     "prettier": "1.7.4",

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2465,7 +2465,7 @@ export module SortedMap {
      * Seq { "R", "Q", "P", "O", "N", "M", "L" }
      * ```
      */
-    from(value: T, backwards?: boolean): Seq<T>;
+    from(value: T, backwards?: boolean): Seq<T, T>;
   }
 
   /**
@@ -3128,7 +3128,7 @@ export module SortedMap {
 
     // Reading values
 
-    has(key: string): key is keyof TProps;
+    has(key: string): key is keyof TProps & string;
 
     /**
      * Returns the value associated with the provided key, which may be the


### PR DESCRIPTION
Also remove unused package microtime, which current Typescript
transpilers don't like.

Tested by importing into nodeutils and compiling.  Also manually
verified that `SortedSet.from` returns something that behaves like a
`Seq<T, T>`:
```ts
> ss = im.SortedSet([1,2,3])
> t23 = ss.from(2)
> t23.entrySeq()
Seq [ 2,2, 3,3 ]
```